### PR TITLE
Add `me` to social link `rel` attribute for Mastodon verification

### DIFF
--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -1,5 +1,5 @@
 {{ range . -}}
 {{ $name := .name }}
 {{ $path := printf "%s" $name | printf "%s%s" "brands/" }}
-<a href="{{ .url }}" target="_blank" rel="noopener" title="{{ .name | humanize }}" aria-label="Ura Design on {{ .name | humanize }}">{{ partial "fontawesome.html" $path }}</a>
+<a href="{{ .url }}" target="_blank" rel="noopener me" title="{{ .name | humanize }}" aria-label="Ura Design on {{ .name | humanize }}">{{ partial "fontawesome.html" $path }}</a>
 {{- end -}}


### PR DESCRIPTION
This makes the Mastodon link to the page verified (green) if it would be added to the Mastodon profile at https://mastodon.online/@uradotdesign

See: https://docs.joinmastodon.org/user/profile/#verification